### PR TITLE
[TS] Fix relative paths for exports

### DIFF
--- a/src/idl_gen_ts.cpp
+++ b/src/idl_gen_ts.cpp
@@ -263,14 +263,9 @@ class TsGenerator : public BaseGenerator {
       for (const auto &def : it.second.definitions) {
         std::vector<std::string> rel_components;
         // build path for root level vs child level
-        if (it.second.ns->components.size() > 1)
-          std::copy(it.second.ns->components.begin() + 1,
-                    it.second.ns->components.end(),
-                    std::back_inserter(rel_components));
-        else
-          std::copy(it.second.ns->components.begin(),
-                    it.second.ns->components.end(),
-                    std::back_inserter(rel_components));
+        std::copy(it.second.ns->components.begin() + it.second.ns->components.size() - 1,
+                  it.second.ns->components.end(),
+                  std::back_inserter(rel_components));
         auto base_file_name =
             namer_.File(*(def.second), SkipFile::SuffixAndExtension);
         auto base_name =

--- a/src/idl_gen_ts.cpp
+++ b/src/idl_gen_ts.cpp
@@ -269,8 +269,7 @@ class TsGenerator : public BaseGenerator {
                     it.second.ns->components.end(),
                     std::back_inserter(rel_components));
         } else {
-          std::copy(it.second.ns->components.begin() +
-                        it.second.ns->components.size(),
+          std::copy(it.second.ns->components.begin(),
                     it.second.ns->components.end(),
                     std::back_inserter(rel_components));
         }

--- a/src/idl_gen_ts.cpp
+++ b/src/idl_gen_ts.cpp
@@ -263,9 +263,17 @@ class TsGenerator : public BaseGenerator {
       for (const auto &def : it.second.definitions) {
         std::vector<std::string> rel_components;
         // build path for root level vs child level
-        std::copy(it.second.ns->components.begin() + it.second.ns->components.size() - 1,
-                  it.second.ns->components.end(),
-                  std::back_inserter(rel_components));
+        if (it.second.ns->components.size() > 0) {
+          std::copy(it.second.ns->components.begin() +
+                        it.second.ns->components.size() - 1,
+                    it.second.ns->components.end(),
+                    std::back_inserter(rel_components));
+        } else {
+          std::copy(it.second.ns->components.begin() +
+                        it.second.ns->components.size(),
+                    it.second.ns->components.end(),
+                    std::back_inserter(rel_components));
+        }
         auto base_file_name =
             namer_.File(*(def.second), SkipFile::SuffixAndExtension);
         auto base_name =

--- a/tests/long_namespace.fbs
+++ b/tests/long_namespace.fbs
@@ -1,0 +1,7 @@
+namespace com.company.test;
+
+table Person {
+  name:string;
+  age:short;
+}
+root_type Person;

--- a/tests/longer_namespace.fbs
+++ b/tests/longer_namespace.fbs
@@ -1,0 +1,7 @@
+namespace a.b.c.d;
+
+table Person {
+  name:string;
+  age:short;
+}
+root_type Person;

--- a/tests/ts/TypeScriptTest.py
+++ b/tests/ts/TypeScriptTest.py
@@ -122,6 +122,16 @@ flatc(
     schema="../union_underlying_type_test.fbs"
 )
 
+flatc(
+    options=["--ts"],
+    schema="../long_namespace.fbs"
+)
+
+flatc(
+    options=["--ts"],
+    schema="../namespace.fbs"
+)
+
 print("Running TypeScript Compiler...")
 check_call(["tsc"])
 print("Running TypeScript Compiler in old node resolution mode for no_import_ext...")


### PR DESCRIPTION
Fixes issue #7898 where exports were using incorrect relative paths for 3 namespace levels. This is fixed by making the starting range of the namespace components relative to the amount of components.
